### PR TITLE
fix custom jre to fix ssl handshake issue

### DIFF
--- a/ant.xml
+++ b/ant.xml
@@ -19,8 +19,6 @@
 			<exec executable="jpackage.exe">
 				<arg value="--input" />
 				<arg value="${jarApp.dir}" />
-				<arg value="--runtime-image" />
-				<arg value="${dir.buildfile}/jre" />
 				<arg value="--dest" />
 				<arg value="${dir.buildfile}/build" />
 				<arg value="--main-jar" />

--- a/jremaker.bat
+++ b/jremaker.bat
@@ -7,6 +7,6 @@ set /p location=<jreLoc.txt
 del jreLoc.txt
 
 @echo on
-"%location%" --output jre --compress=2 --strip-debug --strip-native-commands --no-header-files --no-man-pages --module-path ../jmods --add-modules java.base,java.desktop
+"%location%" --output jre --compress=2 --strip-debug --no-header-files --no-man-pages --module-path ../jmods --add-modules java.base,java.desktop,jdk.crypto.ec
 
 @pause


### PR DESCRIPTION
#6 is fixed for this patch.

- `--strip-native-commands` removes all executable(like `java.exe`, `javaw.exe`, so should be removed from `jremaker.bat`
- `jdk.crypto.ec` module is needed to fix ssl handshake issue.
- Let `jpackage` make it's own jre. 
  It seems `jpackage` includes lots of modules to its custom jre. might have to see if some of those should be included in `jremaker.bat`

modules that `jpackage` adds :
```
jdk.management.jfr
java.rmi
jdk.jdi
jdk.charsets
java.xml
jdk.xml.dom
java.datatransfer
jdk.jstatd
jdk.httpserver
java.desktop
java.security.sasl
jdk.zipfs
java.base
jdk.crypto.ec
jdk.javadoc
jdk.management.agent
jdk.jshell
jdk.editpad
jdk.jsobject
jdk.sctp
java.sql.rowset
jdk.jlink
jdk.unsupported
java.smartcardio
java.security.jgss
java.compiler
jdk.nio.mapmode
jdk.dynalink
jdk.unsupported.desktop
jdk.accessibility
jdk.security.jgss
java.sql
jdk.incubator.vector
java.transaction.xa
java.logging
java.xml.crypto
jdk.jfr
jdk.crypto.cryptoki
jdk.random
jdk.net
java.naming
jdk.internal.ed
java.prefs
java.net.http
jdk.compiler
jdk.internal.opt
jdk.naming.rmi
jdk.jconsole
jdk.attach
jdk.crypto.mscapi
jdk.internal.le
java.management
jdk.jdwp.agent
jdk.internal.jvmstat
jdk.incubator.foreign
java.instrument
jdk.management
jdk.security.auth
java.scripting
jdk.jdeps
jdk.jartool
java.management.rmi
jdk.jpackage
jdk.naming.dns
jdk.localedata
```